### PR TITLE
Implement notes and events APIs

### DIFF
--- a/src/app/Http/Controllers/Event/EventController.php
+++ b/src/app/Http/Controllers/Event/EventController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Event;
+
+use App\Http\Controllers\Controller;
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+
+class EventController extends Controller
+{
+    public function index(Request $request)
+    {
+        $events = Auth::user()->events()->orderBy('event_time')->paginate(10);
+        return response()->json($events);
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'title' => 'required|string|max:200',
+            'description' => 'nullable|string',
+            'event_time' => 'required|date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $event = Event::create([
+            'user_id' => Auth::id(),
+            'title' => $request->title,
+            'description' => $request->description,
+            'event_time' => $request->event_time,
+        ]);
+
+        return response()->json(['message' => 'Event created successfully', 'event' => $event], 201);
+    }
+
+    public function show(Event $event)
+    {
+        if ($event->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        return response()->json($event);
+    }
+
+    public function update(Request $request, Event $event)
+    {
+        if ($event->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title' => 'string|max:200',
+            'description' => 'nullable|string',
+            'event_time' => 'date',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $event->update($request->only(['title', 'description', 'event_time']));
+
+        return response()->json(['message' => 'Event updated successfully', 'event' => $event]);
+    }
+
+    public function destroy(Event $event)
+    {
+        if ($event->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        $event->delete();
+        return response()->json(['message' => 'Event deleted successfully']);
+    }
+}

--- a/src/app/Http/Controllers/Note/NoteController.php
+++ b/src/app/Http/Controllers/Note/NoteController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Note;
+
+use App\Http\Controllers\Controller;
+use App\Models\Note;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+
+class NoteController extends Controller
+{
+    public function index(Request $request)
+    {
+        $notes = Auth::user()->notes()->orderBy('created_at', 'desc')->paginate(10);
+        return response()->json($notes);
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'title' => 'required|string|max:200',
+            'content' => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $note = Note::create([
+            'user_id' => Auth::id(),
+            'title' => $request->title,
+            'content' => $request->content,
+        ]);
+
+        return response()->json(['message' => 'Note created successfully', 'note' => $note], 201);
+    }
+
+    public function show(Note $note)
+    {
+        if ($note->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        return response()->json($note);
+    }
+
+    public function update(Request $request, Note $note)
+    {
+        if ($note->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title' => 'string|max:200',
+            'content' => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $note->update($request->only(['title', 'content']));
+
+        return response()->json(['message' => 'Note updated successfully', 'note' => $note]);
+    }
+
+    public function destroy(Note $note)
+    {
+        if ($note->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        $note->delete();
+        return response()->json(['message' => 'Note deleted successfully']);
+    }
+}

--- a/src/app/Models/Event.php
+++ b/src/app/Models/Event.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Event extends Model
+{
+    protected $table = 'Events';
+    protected $primaryKey = 'event_id';
+    public $timestamps = true;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'description',
+        'event_time',
+    ];
+
+    protected $casts = [
+        'event_time' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'user_id');
+    }
+
+    public function goals(): BelongsToMany
+    {
+        return $this->belongsToMany(Goal::class, 'event_goal_links', 'event_id', 'goal_id');
+    }
+}

--- a/src/app/Models/Milestone.php
+++ b/src/app/Models/Milestone.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Milestone extends Model
+{
+    protected $table = 'Milestones';
+    protected $primaryKey = 'milestone_id';
+    public $timestamps = true;
+
+    protected $fillable = [
+        'goal_id',
+        'title',
+        'deadline',
+        'is_completed',
+    ];
+
+    protected $casts = [
+        'deadline' => 'date',
+        'is_completed' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function goal(): BelongsTo
+    {
+        return $this->belongsTo(Goal::class, 'goal_id', 'goal_id');
+    }
+
+    public function notes(): BelongsToMany
+    {
+        return $this->belongsToMany(Note::class, 'note_milestone_links', 'milestone_id', 'note_id');
+    }
+}

--- a/src/app/Models/Note.php
+++ b/src/app/Models/Note.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Note extends Model
+{
+    protected $table = 'Notes';
+    protected $primaryKey = 'note_id';
+    public $timestamps = true;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'content',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'user_id');
+    }
+
+    public function goals(): BelongsToMany
+    {
+        return $this->belongsToMany(Goal::class, 'note_goal_links', 'note_id', 'goal_id');
+    }
+
+    public function milestones(): BelongsToMany
+    {
+        return $this->belongsToMany(Milestone::class, 'note_milestone_links', 'note_id', 'milestone_id');
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -34,6 +34,30 @@ Route::middleware('auth:sanctum')->group(function () {
     });
     Route::get('/me', [AuthController::class, 'me']);
     Route::post('/logout', [AuthController::class, 'logout']);
+
+    // Goal management
+    Route::get('/goals', [\App\Http\Controllers\Goal\GoalController::class, 'index']);
+    Route::post('/goals', [\App\Http\Controllers\Goal\GoalController::class, 'store']);
+    Route::get('/goals/{goal}', [\App\Http\Controllers\Goal\GoalController::class, 'show']);
+    Route::put('/goals/{goal}', [\App\Http\Controllers\Goal\GoalController::class, 'update']);
+    Route::delete('/goals/{goal}', [\App\Http\Controllers\Goal\GoalController::class, 'destroy']);
+    Route::post('/goals/{goal}/collaborators', [\App\Http\Controllers\Goal\GoalController::class, 'addCollaborator']);
+    Route::delete('/goals/{goal}/collaborators/{userId}', [\App\Http\Controllers\Goal\GoalController::class, 'removeCollaborator']);
+    Route::put('/goals/{goal}/share', [\App\Http\Controllers\Goal\GoalController::class, 'updateShareSettings']);
+
+    // Notes
+    Route::get('/notes', [\App\Http\Controllers\Note\NoteController::class, 'index']);
+    Route::post('/notes', [\App\Http\Controllers\Note\NoteController::class, 'store']);
+    Route::get('/notes/{note}', [\App\Http\Controllers\Note\NoteController::class, 'show']);
+    Route::put('/notes/{note}', [\App\Http\Controllers\Note\NoteController::class, 'update']);
+    Route::delete('/notes/{note}', [\App\Http\Controllers\Note\NoteController::class, 'destroy']);
+
+    // Events
+    Route::get('/events', [\App\Http\Controllers\Event\EventController::class, 'index']);
+    Route::post('/events', [\App\Http\Controllers\Event\EventController::class, 'store']);
+    Route::get('/events/{event}', [\App\Http\Controllers\Event\EventController::class, 'show']);
+    Route::put('/events/{event}', [\App\Http\Controllers\Event\EventController::class, 'update']);
+    Route::delete('/events/{event}', [\App\Http\Controllers\Event\EventController::class, 'destroy']);
 });
 
 // Thêm routes cho callbacks trực tiếp không phụ thuộc session


### PR DESCRIPTION
## Summary
- add `Note`, `Milestone` and `Event` Eloquent models
- create `NoteController` and `EventController`
- expose CRUD endpoints for notes, events and goals in API routes

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a1651ed0832d9a82580a307c52f8