### PR TITLE
Implement basic goal & milestone API

### DIFF
--- a/src/app/Http/Controllers/Goal/MilestoneController.php
+++ b/src/app/Http/Controllers/Goal/MilestoneController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Goal;
+
+use App\Http\Controllers\Controller;
+use App\Models\Goal;
+use App\Models\Milestone;
+use App\Models\GoalProgress;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+
+class MilestoneController extends Controller
+{
+    public function index(Goal $goal)
+    {
+        if ($goal->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        return response()->json($goal->milestones);
+    }
+
+    public function store(Request $request, Goal $goal)
+    {
+        if ($goal->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title' => 'required|string|max:200',
+            'deadline' => 'nullable|date'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $milestone = $goal->milestones()->create([
+            'title' => $request->title,
+            'deadline' => $request->deadline,
+            'is_completed' => false
+        ]);
+
+        $this->updateGoalProgress($goal);
+
+        return response()->json(['milestone' => $milestone], 201);
+    }
+
+    public function update(Request $request, Goal $goal, Milestone $milestone)
+    {
+        if ($goal->user_id !== Auth::id() || $milestone->goal_id !== $goal->goal_id) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'title' => 'string|max:200',
+            'deadline' => 'nullable|date',
+            'is_completed' => 'boolean'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $milestone->update($request->only(['title','deadline','is_completed']));
+        $this->updateGoalProgress($goal);
+
+        return response()->json(['milestone' => $milestone]);
+    }
+
+    public function destroy(Goal $goal, Milestone $milestone)
+    {
+        if ($goal->user_id !== Auth::id() || $milestone->goal_id !== $goal->goal_id) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        $milestone->delete();
+        $this->updateGoalProgress($goal);
+        return response()->json(['message' => 'Milestone deleted']);
+    }
+
+    protected function updateGoalProgress(Goal $goal): void
+    {
+        $progressValue = $goal->calculateProgress();
+        GoalProgress::updateOrCreate(
+            ['goal_id' => $goal->goal_id],
+            ['progress_value' => $progressValue]
+        );
+        $goal->updateStatus();
+    }
+}

--- a/src/app/Models/GoalCollaboration.php
+++ b/src/app/Models/GoalCollaboration.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GoalCollaboration extends Model
+{
+    public $timestamps = false;
+    protected $table = 'GoalCollaboration';
+    protected $primaryKey = 'collab_id';
+
+    protected $fillable = [
+        'goal_id',
+        'user_id',
+        'role',
+        'joined_at'
+    ];
+
+    protected $casts = [
+        'joined_at' => 'datetime'
+    ];
+
+    public function goal(): BelongsTo
+    {
+        return $this->belongsTo(Goal::class, 'goal_id', 'goal_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'user_id');
+    }
+}

--- a/src/app/Models/GoalProgress.php
+++ b/src/app/Models/GoalProgress.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GoalProgress extends Model
+{
+    public $timestamps = false;
+    protected $table = 'GoalProgress';
+    protected $primaryKey = 'progress_id';
+
+    protected $fillable = [
+        'goal_id',
+        'progress_value'
+    ];
+
+    protected $casts = [
+        'progress_value' => 'float',
+        'updated_at' => 'datetime'
+    ];
+
+    public function goal(): BelongsTo
+    {
+        return $this->belongsTo(Goal::class, 'goal_id', 'goal_id');
+    }
+}

--- a/src/app/Models/GoalShare.php
+++ b/src/app/Models/GoalShare.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GoalShare extends Model
+{
+    public $timestamps = false;
+    protected $table = 'GoalShares';
+    protected $primaryKey = 'share_id';
+
+    protected $fillable = [
+        'goal_id',
+        'share_type',
+        'shared_at'
+    ];
+
+    protected $casts = [
+        'shared_at' => 'datetime'
+    ];
+
+    public function goal(): BelongsTo
+    {
+        return $this->belongsTo(Goal::class, 'goal_id', 'goal_id');
+    }
+}

--- a/src/app/Models/Milestone.php
+++ b/src/app/Models/Milestone.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Milestone extends Model
+{
+    protected $table = 'Milestones';
+    protected $primaryKey = 'milestone_id';
+
+    protected $fillable = [
+        'goal_id',
+        'title',
+        'deadline',
+        'is_completed'
+    ];
+
+    protected $casts = [
+        'deadline' => 'date',
+        'is_completed' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime'
+    ];
+
+    public function goal(): BelongsTo
+    {
+        return $this->belongsTo(Goal::class, 'goal_id', 'goal_id');
+    }
+}

--- a/src/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/src/database/migrations/0001_01_01_000000_create_users_table.php
@@ -11,13 +11,17 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
-            $table->id();
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
+        Schema::create('Users', function (Blueprint $table) {
+            $table->id('user_id');
+            $table->string('display_name', 100);
+            $table->string('email', 100)->unique();
+            $table->string('password_hash');
+            $table->string('avatar_url', 255)->nullable();
+            $table->enum('registration_type', ['email','google','facebook']);
+            $table->enum('status', ['active','banned','pending','unverified'])->default('unverified');
+            $table->string('reset_token', 255)->nullable();
+            $table->string('verification_token', 255)->nullable();
+            $table->timestamp('last_login_at')->nullable();
             $table->timestamps();
         });
 
@@ -29,7 +33,7 @@ return new class extends Migration
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->foreignId('user_id')->nullable()->index();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->longText('payload');
@@ -42,7 +46,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('users');
+        Schema::dropIfExists('Users');
         Schema::dropIfExists('password_reset_tokens');
         Schema::dropIfExists('sessions');
     }

--- a/src/database/migrations/2025_07_01_000001_create_goals_table.php
+++ b/src/database/migrations/2025_07_01_000001_create_goals_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('Goals', function (Blueprint $table) {
+            $table->id('goal_id');
+            $table->unsignedBigInteger('user_id');
+            $table->string('title', 200);
+            $table->text('description')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->enum('status', ['new','in_progress','completed','cancelled'])->default('new');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('Goals');
+    }
+};

--- a/src/database/migrations/2025_07_01_000002_create_milestones_table.php
+++ b/src/database/migrations/2025_07_01_000002_create_milestones_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('Milestones', function (Blueprint $table) {
+            $table->id('milestone_id');
+            $table->unsignedBigInteger('goal_id');
+            $table->string('title', 200);
+            $table->date('deadline')->nullable();
+            $table->boolean('is_completed')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('Milestones');
+    }
+};

--- a/src/database/migrations/2025_07_01_000003_create_goal_progress_table.php
+++ b/src/database/migrations/2025_07_01_000003_create_goal_progress_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('GoalProgress', function (Blueprint $table) {
+            $table->id('progress_id');
+            $table->unsignedBigInteger('goal_id');
+            $table->float('progress_value');
+            $table->timestamp('updated_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('GoalProgress');
+    }
+};

--- a/src/database/migrations/2025_07_01_000004_create_goal_shares_table.php
+++ b/src/database/migrations/2025_07_01_000004_create_goal_shares_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('GoalShares', function (Blueprint $table) {
+            $table->id('share_id');
+            $table->unsignedBigInteger('goal_id');
+            $table->enum('share_type', ['private','public','friends','collaboration'])->default('private');
+            $table->timestamp('shared_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('GoalShares');
+    }
+};

--- a/src/database/migrations/2025_07_01_000005_create_goal_collaborations_table.php
+++ b/src/database/migrations/2025_07_01_000005_create_goal_collaborations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('GoalCollaboration', function (Blueprint $table) {
+            $table->id('collab_id');
+            $table->unsignedBigInteger('goal_id');
+            $table->unsignedBigInteger('user_id');
+            $table->enum('role', ['owner','member'])->default('member');
+            $table->timestamp('joined_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('GoalCollaboration');
+    }
+};

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,6 +2,8 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\AuthController;
+use App\Http\Controllers\Goal\GoalController;
+use App\Http\Controllers\Goal\MilestoneController;
 
 // Các routes công khai - không yêu cầu xác thực
 Route::post('/register', [AuthController::class, 'register']);
@@ -34,6 +36,15 @@ Route::middleware('auth:sanctum')->group(function () {
     });
     Route::get('/me', [AuthController::class, 'me']);
     Route::post('/logout', [AuthController::class, 'logout']);
+
+    // Goal management
+    Route::apiResource('goals', GoalController::class);
+
+    // Milestone management nested under goals
+    Route::get('goals/{goal}/milestones', [MilestoneController::class, 'index']);
+    Route::post('goals/{goal}/milestones', [MilestoneController::class, 'store']);
+    Route::put('goals/{goal}/milestones/{milestone}', [MilestoneController::class, 'update']);
+    Route::delete('goals/{goal}/milestones/{milestone}', [MilestoneController::class, 'destroy']);
 });
 
 // Thêm routes cho callbacks trực tiếp không phụ thuộc session


### PR DESCRIPTION
## Summary
- update users table migration to match project schema
- add migrations for goals, milestones, progress, shares and collaborations
- add models for milestones and goal-related tables
- add milestone controller and routes for CRUD under goals

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68579de65db0832d859e2488109200c0